### PR TITLE
fixed qxl value vor vga param

### DIFF
--- a/cloud/misc/proxmox_kvm.py
+++ b/cloud/misc/proxmox_kvm.py
@@ -460,7 +460,7 @@ options:
   vga:
     description:
      - select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'
-    choices: ['std', 'cirrus', 'vmware', 'qx', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']
+    choices: ['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']
     required: false
     default: std
   virtio:
@@ -831,7 +831,7 @@ def main():
       timeout = dict(type='int', default=30),
       validate_certs = dict(type='bool', default='no'),
       vcpus = dict(type='int', default=None),
-      vga = dict(default='std', choices=['std', 'cirrus', 'vmware', 'qx', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
+      vga = dict(default='std', choices=['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
       virtio = dict(type='dict', default=None),
       vmid = dict(type='int', default=None),
       watchdog = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

proxmox_kvm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

> | Name | Type | Format | Description |
> |------|------|--------|-------------|
> | vga | enum | std \| cirrus \| vmware \| qxl \| serial0 \| serial1 \| serial2 \| serial3 \| qxl2 \| qxl3 \| qxl4 | Select the VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use the options 'std' or 'vmware'. Default is 'std' for win8/win7/w2k8, and 'cirrus' for other OS types. The 'qxl' option enables the SPICE display sever. For win* OS you can select how many independent displays you want, Linux guests can add displays them self. You can also run without any graphic card, using a serial device as terminal. |